### PR TITLE
Allow more wide deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/JakeSidSmith/react-fastclick",
   "dependencies": {
-    "react": "0.13.3"
+    "react": "^0.12.0"
   },
   "devDependencies": {
     "jscs": "1.13.1",


### PR DESCRIPTION
I'm working on React 0.12.x tablet app and tested react-fastclick, and it seems there is no problem at all. Do you mind allowing 0.12.x as deps?
