### PR TITLE
Refactor to work with React 0.14 (and older)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **Instantly make your desktop / hybrid apps more responsive on touch devices.**
 
-React Fastclick automatically adds fastclick touch events to elements with onClick attributes to prevent the delay that occurs on some touch devices.
+React Fastclick automatically adds fastclick touch events to elements with onClick attributes (and those that require special functionality, such as inputs) to prevent the delay that occurs on some touch devices.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -62,4 +62,6 @@ Either target `html, body` (to prevent the flickering on all elements) or target
 
 ## Support
 
-Currently only tested with React 0.12.x & 0.13.x
+React Fastclick version 2.x.x has only been tested with React 0.14.x but should work with older versions
+
+React Fastclick versions less than 2.x.x only work with React 0.13.x or less (tested with 0.12.x & 0.13.x) and do not have all the same functionality as React Fastclick 2.x.x (refer to relevant readme)

--- a/README.md
+++ b/README.md
@@ -66,8 +66,4 @@ Either target `html, body` (to prevent the flickering on all elements) or target
 
 ## Support
 
-React Fastclick version 2.x.x has only been tested with React 0.14.x but should work with older versions
-
-React Fastclick less than version 2.x.x is not recommended.
-
-React Fastclick versions less than 2.x.x only work with React 0.13.x or less (tested with 0.12.x & 0.13.x) and do not have all the same functionality as React Fastclick 2.x.x (refer to relevant readme). There were also several bugs that were only fixed in version 2.x.x.
+React Fastclick version 2.x.x has been tested with React 0.12, 0.13 and 0.14, and should work with even older versions.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install react-fastclick
 
 ## Usage
 
-Include react-fastclick in your main javascript file before any of your components are created, and you're done.
+Include `react-fastclick` in your main javascript file before any of your components are created, and you're done.
 
 Now any calls to onClick will have fast touch events added automatically - no need to write any additional listeners.
 
@@ -33,11 +33,27 @@ require('react-fastclick');
 
 ## Notes
 
-1. The event triggered on touch devices is currently the same event for `touchend`, and will have `event.type` `touchend`. This also means that it wont have any mouse / touch coordinates (e.g. `event.touches`, `clientX`, `pageX`).
+1. The event triggered on touch devices is a modified `touchend` event. This means that it may have some keys that are unusual for a click event.
 
-    I will be creating synthetic events for these shortly with the most recent touch / mouse coords.
+  In order to simulate a click as best as possible, this event is populated with the following keys / values. All positions are taken from the last know touch position.
 
-    See this [issue](https://github.com/JakeSidSmith/react-fastclick/issues/4)
+  ```javascript
+  {
+    // Simulate left click
+    button: 0,
+    type: 'click',
+    // Additional key to tell the difference between
+    // a regular click and a flastclick
+    fastclick: true,
+    // From touch positions
+    clientX,
+    clientY,
+    pageX,
+    pageY,
+    screenX,
+    screenY
+  }
+  ```
 
 2. On some devices the elements flicker after being touched. This can be prevented by setting the css property `-webkit-tap-highlight-color` to transparent.
 Either target `html, body` (to prevent the flickering on all elements) or target the specific element you don't want to flicker e.g. `button`.

--- a/README.md
+++ b/README.md
@@ -68,4 +68,6 @@ Either target `html, body` (to prevent the flickering on all elements) or target
 
 React Fastclick version 2.x.x has only been tested with React 0.14.x but should work with older versions
 
-React Fastclick versions less than 2.x.x only work with React 0.13.x or less (tested with 0.12.x & 0.13.x) and do not have all the same functionality as React Fastclick 2.x.x (refer to relevant readme)
+React Fastclick less than version 2.x.x is not recommended.
+
+React Fastclick versions less than 2.x.x only work with React 0.13.x or less (tested with 0.12.x & 0.13.x) and do not have all the same functionality as React Fastclick 2.x.x (refer to relevant readme). There were also several bugs that were only fixed in version 2.x.x.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install react-fastclick
 
 Include `react-fastclick` in your main javascript file before any of your components are created, and you're done.
 
-Now any calls to onClick will have fast touch events added automatically - no need to write any additional listeners.
+Now any calls to onClick  or elements with special functionality, such as inputs, will have fast touch events added automatically - no need to write any additional listeners.
 
 **ES6**
 

--- a/README.md
+++ b/README.md
@@ -19,28 +19,16 @@ Include react-fastclick in your main javascript file before any of your componen
 
 Now any calls to onClick will have fast touch events added automatically - no need to write any additional listeners.
 
-Example:
+**ES6**
 
 ```javascript
-'use strict';
+import 'react-fastclick';
+```
 
+**ES5**
+
+```javascript
 require('react-fastclick');
-var React = require('react');
-
-var App = React.createClass({
-  logEventType: function (event) {
-    console.log(event.type);
-  },
-  render: function() {
-    return (
-      <p onClick={this.logEventType}>
-        Hello, world!
-      </p>
-    );
-  }
-});
-
-React.render(<App />, document.body);
 ```
 
 ## Notes

--- a/index.js
+++ b/index.js
@@ -155,10 +155,10 @@
     if (!touchEvents.invalid && !touchEvents.moved) {
       var box = event.currentTarget.getBoundingClientRect();
 
-      if (touchEvents.lastPos.clientX <= box.right &&
-        touchEvents.lastPos.clientX >= box.left &&
-        touchEvents.lastPos.clientY <= box.bottom &&
-        touchEvents.lastPos.clientY >= box.top) {
+      if (touchEvents.lastPos.clientX - touchEvents.lastPos.radiusX <= box.right &&
+        touchEvents.lastPos.clientX + touchEvents.lastPos.radiusX >= box.left &&
+        touchEvents.lastPos.clientY - touchEvents.lastPos.radiusY <= box.bottom &&
+        touchEvents.lastPos.clientY + touchEvents.lastPos.radiusY >= box.top) {
 
         if (typeof onClick === 'function') {
           copyTouchKeys(touchEvents.lastPos, event);

--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@
     newProps.onTouchMove = onTouchMove.bind(null, props.onTouchMove);
     newProps.onTouchEnd = onTouchEnd.bind(null, props.onTouchEnd, props.onClick);
 
+    if (Object.freeze) {
+      Object.freeze(newProps);
+    }
+
     return newProps;
   };
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@
   };
 
   var onTouchStart = function (callback, event) {
+    touchEvents.moved = false;
     touchEvents.touched = true;
     touchEvents.lastTouchDate = new Date().getTime();
     touchEvents.downPos = {
@@ -44,10 +45,6 @@
     };
     touchEvents.invalid = false;
     invalidateIfMoreThanOneTouch(event);
-
-    if (!touchEvents.invalid) {
-      touchEvents.moved = false;
-    }
 
     if (typeof callback === 'function') {
       callback(event);

--- a/index.js
+++ b/index.js
@@ -21,8 +21,6 @@
   };
 
   var onMouseEvent = function (callback, event) {
-    console.log('mouse event wrapper', event.type);
-
     // Prevent original click if we touched recently
     if (typeof callback === 'function' && noTouchHappened()) {
       callback(event);
@@ -34,8 +32,6 @@
   };
 
   var onTouchStart = function (callback, event) {
-    console.log('onTouchStart wrapper');
-
     touchEvents.touched = true;
     touchEvents.lastTouchDate = new Date().getTime();
     touchEvents.downPos = {
@@ -59,8 +55,6 @@
   };
 
   var onTouchMove = function (callback, event) {
-    console.log('onTouchMove wrapper');
-
     touchEvents.touched = true;
     touchEvents.lastTouchDate = new Date().getTime();
     touchEvents.lastPos = {
@@ -81,8 +75,6 @@
   };
 
   var onTouchEnd = function (callback, onClick, event) {
-    console.log('onTouchEnd wrapper');
-
     touchEvents.touched = true;
     touchEvents.lastTouchDate = new Date().getTime();
     invalidateIfMoreThanOneTouch(event);
@@ -105,8 +97,6 @@
   };
 
   var onCancel = function () {
-    console.log('Cancel');
-
     touchEvents.touched = true;
     touchEvents.lastTouchDate = new Date().getTime();
   };

--- a/index.js
+++ b/index.js
@@ -60,8 +60,7 @@
     };
     invalidateIfMoreThanOneTouch(event);
 
-    if (!touchEvents.invalid &&
-      Math.abs(touchEvents.downPos.clientX - touchEvents.lastPos.clientX) > MOVE_THRESHOLD ||
+    if (Math.abs(touchEvents.downPos.clientX - touchEvents.lastPos.clientX) > MOVE_THRESHOLD ||
       Math.abs(touchEvents.downPos.clientY - touchEvents.lastPos.clientY) > MOVE_THRESHOLD) {
       touchEvents.moved = true;
     }

--- a/index.js
+++ b/index.js
@@ -150,4 +150,10 @@
     return originalCreateElement.apply(null, args);
   };
 
+  if (typeof React.DOM === 'object') {
+    for (var key in React.DOM) {
+      React.DOM[key] = React.createElement.bind(null, key);
+    }
+  }
+
 })();

--- a/index.js
+++ b/index.js
@@ -179,7 +179,9 @@
     var props = args[1];
 
     // Check if basic element & has onClick prop
-    if (type && typeof type === 'string') {
+    if (type && typeof type === 'string' && (
+      (props && typeof props.onClick === 'function') || handleType[type]
+    )) {
       // Add our own events to props
       args[1] = propsWithFastclickEvents(type, props || {});
     }

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@
     newProps.onTouchMove = onTouchMove.bind(null, props.onTouchMove);
     newProps.onTouchEnd = onTouchEnd.bind(null, props.onTouchEnd, props.onClick);
 
-    if (Object.freeze) {
+    if (typeof Object.freeze === 'function') {
       Object.freeze(newProps);
     }
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@
     input: function (event) {
       focusOrCheck(event.currentTarget);
     },
+    textarea: function (event) {
+      focusOrCheck(event.currentTarget);
+    },
+    select: function (event) {
+      focusOrCheck(event.currentTarget);
+    },
     label: function (event) {
       var input;
 
@@ -34,7 +40,7 @@
       if (forTarget) {
         input = document.getElementById(forTarget);
       } else {
-        input = event.currentTarget.getElementsByTagName('input')[0];
+        input = event.currentTarget.querySelectorAll('input, textarea, select')[0];
       }
 
       if (input) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@
   };
 
   var onMouseEvent = function (callback, event) {
-    // Prevent original click if we touched recently
+    // Prevent any mouse events if we touched recently
     if (typeof callback === 'function' && noTouchHappened()) {
       callback(event);
     }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@
 
   var touchEvents = {};
 
-  var focusOrCheck = function (event, target) {
+  var focusAndCheck = function (event, target) {
     var myTarget = target || event.currentTarget;
     myTarget.focus();
 
@@ -30,15 +30,15 @@
 
   var handleType = {
     input: function (event) {
-      focusOrCheck(event);
+      focusAndCheck(event);
       event.stopPropagation();
     },
     textarea: function (event) {
-      focusOrCheck(event);
+      focusAndCheck(event);
       event.stopPropagation();
     },
     select: function (event) {
-      focusOrCheck(event);
+      focusAndCheck(event);
       event.stopPropagation();
     },
     label: function (event) {
@@ -53,7 +53,7 @@
       }
 
       if (input) {
-        focusOrCheck(event, input);
+        focusAndCheck(event, input);
       }
       event.preventDefault();
     }

--- a/index.js
+++ b/index.js
@@ -96,11 +96,6 @@
     }
   };
 
-  var onCancel = function () {
-    touchEvents.touched = true;
-    touchEvents.lastTouchDate = new Date().getTime();
-  };
-
   var propsWithFastclickEvents = function (props) {
     var newProps = {};
 

--- a/index.js
+++ b/index.js
@@ -75,14 +75,13 @@
     touchEvents.lastTouchDate = new Date().getTime();
     invalidateIfMoreThanOneTouch(event);
 
-    if (!touchEvents.invalid && !touchEvents.moved &&
-      Math.abs(touchEvents.downPos.clientX - touchEvents.lastPos.clientX) <= MOVE_THRESHOLD &&
-      Math.abs(touchEvents.downPos.clientY - touchEvents.lastPos.clientY) <= MOVE_THRESHOLD) {
-      if (typeof callback === 'function') {
-        callback(event);
-      }
+    if (typeof callback === 'function') {
+      callback(event);
+    }
 
+    if (!touchEvents.invalid && !touchEvents.moved) {
       var box = event.target.getBoundingClientRect();
+
       if (touchEvents.lastPos.clientX <= box.right &&
         touchEvents.lastPos.clientX >= box.left &&
         touchEvents.lastPos.clientY <= box.bottom &&
@@ -97,7 +96,7 @@
 
     // Loop over props
     for (var key in props) {
-      // Copy most props to newProps
+      // Copy props to newProps
       newProps[key] = props[key];
     }
 

--- a/index.js
+++ b/index.js
@@ -12,27 +12,33 @@
 
   var touchEvents = {};
 
-  var focusOrCheck = function (target) {
-    target.focus();
+  var focusOrCheck = function (event, target) {
+    var myTarget = target || event.currentTarget;
+    myTarget.focus();
 
-    if (target.type === 'checkbox') {
-      target.checked = !target.checked;
-    } else if (target.type === 'radio') {
-      target.checked = true;
+    switch (myTarget.type) {
+      case 'checkbox':
+        myTarget.checked = !myTarget.checked;
+        event.preventDefault();
+        break;
+      case 'radio':
+        myTarget.checked = true;
+        event.preventDefault();
+        break;
     }
   };
 
   var handleType = {
     input: function (event) {
-      focusOrCheck(event.currentTarget);
-      event.preventDefault();
+      focusOrCheck(event);
+      event.stopPropagation();
     },
     textarea: function (event) {
-      focusOrCheck(event.currentTarget);
-      event.preventDefault();
+      focusOrCheck(event);
+      event.stopPropagation();
     },
     select: function (event) {
-      focusOrCheck(event.currentTarget);
+      focusOrCheck(event);
       event.stopPropagation();
     },
     label: function (event) {
@@ -47,7 +53,7 @@
       }
 
       if (input) {
-        focusOrCheck(input);
+        focusOrCheck(event, input);
       }
       event.preventDefault();
     }

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@
     // Check if basic element & has onClick prop
     if (type && typeof type === 'string' &&
       props && typeof props.onClick === 'function') {
-      // Push type and props into props
+      // Add our own events to props
       args[1] = propsWithFastclickEvents(props);
     }
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@
     if (event.type === 'click') {
       touchEvents.invalid = false;
       touchEvents.touched = false;
+      touchEvents.moved = false;
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@
 
         if (typeof onClick === 'function') {
           copyTouchKeys(touchEvents.lastPos, event);
-          fakeClickEvent(event)
+          fakeClickEvent(event);
           onClick(event);
         }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,14 @@
 
   var touchEvents = {};
 
+  var fakeClickEvent = function (event) {
+    event.fastclick = true;
+    event.type = 'click';
+    event.button = 0;
+
+    return event;
+  };
+
   var focusAndCheck = function (event, target) {
     var myTarget = target || event.currentTarget;
     myTarget.focus();
@@ -136,7 +144,7 @@
         touchEvents.lastPos.clientY >= box.top) {
 
         if (typeof onClick === 'function') {
-          onClick(event);
+          onClick(fakeClickEvent(event));
         }
 
         if (!event.defaultPrevented && handleType[type]) {

--- a/index.js
+++ b/index.js
@@ -6,173 +6,131 @@
 
   var originalCreateElement = React.createElement;
 
-  var addListener = function (target, eventType, callback) {
-    if (target.addEventListener) {
-      target.addEventListener(eventType, callback, false);
-    } else if (target.attachEvent) {
-      target.attachEvent('on' + eventType, callback, false);
-    }
-  };
-
-  var removeListener = function (target, eventType, callback) {
-    if (target.removeEventListener) {
-      target.removeEventListener(eventType, callback, false);
-    } else if (target.detachEvent) {
-      target.detachEvent('on' + eventType, callback, false);
-    }
-  };
-
   // Moved if Math.abs(downX - upX) > MOVE_THRESHOLD;
   var MOVE_THRESHOLD = 8;
   var TOUCH_DELAY = 1000;
 
   var touchEvents = {};
 
-  var FastClickWrapper = React.createClass({
-    noTouchHappened: function () {
-      return !touchEvents.touched || new Date().getDate() > touchEvents.lastTouchDate + TOUCH_DELAY;
-    },
+  var noTouchHappened = function () {
+    return !touchEvents.touched || new Date().getDate() > touchEvents.lastTouchDate + TOUCH_DELAY;
+  };
 
-    invalidateIfMoreThanOneTouch: function (event) {
-      touchEvents.invalid = event.touches && event.touches.length > 1 || touchEvents.invalid;
-    },
+  var invalidateIfMoreThanOneTouch = function (event) {
+    touchEvents.invalid = event.touches && event.touches.length > 1 || touchEvents.invalid;
+  };
 
-    onMouseEvent: function (callback, event) {
-      console.log('mouse event wrapper', event.type);
+  var onMouseEvent = function (callback, event) {
+    console.log('mouse event wrapper', event.type);
 
-      // Prevent original click if we touched recently
-      if (typeof callback === 'function' && this.noTouchHappened()) {
+    // Prevent original click if we touched recently
+    if (typeof callback === 'function' && noTouchHappened()) {
+      callback(event);
+    }
+    if (event.type === 'click') {
+      touchEvents.invalid = false;
+      touchEvents.touched = false;
+    }
+  };
+
+  var onTouchStart = function (callback, event) {
+    console.log('onTouchStart wrapper');
+
+    touchEvents.touched = true;
+    touchEvents.lastTouchDate = new Date().getTime();
+    touchEvents.downPos = {
+      clientX: event.touches[0].clientX,
+      clientY: event.touches[0].clientY
+    };
+    touchEvents.lastPos = {
+      clientX: event.touches[0].clientX,
+      clientY: event.touches[0].clientY
+    };
+    touchEvents.invalid = false;
+    invalidateIfMoreThanOneTouch(event);
+
+    if (!touchEvents.invalid) {
+      touchEvents.moved = false;
+    }
+
+    if (typeof callback === 'function') {
+      callback(event);
+    }
+  };
+
+  var onTouchMove = function (callback, event) {
+    console.log('onTouchMove wrapper');
+
+    touchEvents.touched = true;
+    touchEvents.lastTouchDate = new Date().getTime();
+    touchEvents.lastPos = {
+      clientX: event.touches[0].clientX,
+      clientY: event.touches[0].clientY
+    };
+    invalidateIfMoreThanOneTouch(event);
+
+    if (!touchEvents.invalid &&
+      Math.abs(touchEvents.downPos.clientX - touchEvents.lastPos.clientX) > MOVE_THRESHOLD ||
+      Math.abs(touchEvents.downPos.clientY - touchEvents.lastPos.clientY) > MOVE_THRESHOLD) {
+      touchEvents.moved = true;
+    }
+
+    if (typeof callback === 'function') {
+      callback(event);
+    }
+  };
+
+  var onTouchEnd = function (callback, onClick, event) {
+    console.log('onTouchEnd wrapper');
+
+    touchEvents.touched = true;
+    touchEvents.lastTouchDate = new Date().getTime();
+    invalidateIfMoreThanOneTouch(event);
+
+    if (!touchEvents.invalid && !touchEvents.moved &&
+      Math.abs(touchEvents.downPos.clientX - touchEvents.lastPos.clientX) <= MOVE_THRESHOLD &&
+      Math.abs(touchEvents.downPos.clientY - touchEvents.lastPos.clientY) <= MOVE_THRESHOLD) {
+      if (typeof callback === 'function') {
         callback(event);
       }
-      if (event.type === 'click') {
-        touchEvents.invalid = false;
-        touchEvents.touched = false;
+
+      var box = event.target.getBoundingClientRect();
+      if (touchEvents.lastPos.clientX <= box.right &&
+        touchEvents.lastPos.clientX >= box.left &&
+        touchEvents.lastPos.clientY <= box.bottom &&
+        touchEvents.lastPos.clientY >= box.top) {
+        onClick(event);
       }
-    },
-
-    onTouchStart: function (event) {
-      console.log('onTouchStart wrapper');
-
-      touchEvents.touched = true;
-      touchEvents.lastTouchDate = new Date().getTime();
-      touchEvents.downPos = {
-        clientX: event.touches[0].clientX,
-        clientY: event.touches[0].clientY
-      };
-      touchEvents.lastPos = {
-        clientX: event.touches[0].clientX,
-        clientY: event.touches[0].clientY
-      };
-      touchEvents.invalid = false;
-      this.invalidateIfMoreThanOneTouch(event);
-
-      if (typeof this.props.props.onTouchStart === 'function') {
-        this.props.props.onTouchStart(event);
-      }
-
-      this.addListeners();
-    },
-
-    onTouchMoveWindow: function (event) {
-      console.log('onTouchMove wrapper');
-
-      touchEvents.touched = true;
-      touchEvents.lastTouchDate = new Date().getTime();
-      touchEvents.lastPos = {
-        clientX: event.touches[0].clientX,
-        clientY: event.touches[0].clientY
-      };
-      this.invalidateIfMoreThanOneTouch(event);
-    },
-
-    onTouchEndWindow: function (event) {
-      console.log('onTouchEnd wrapper');
-
-      touchEvents.touched = true;
-      touchEvents.lastTouchDate = new Date().getTime();
-      this.invalidateIfMoreThanOneTouch(event);
-
-      this.removeListeners();
-    },
-
-    onTouchEnd: function (callback, event) {
-      console.log('onTouchEnd wrapper');
-
-      touchEvents.touched = true;
-      touchEvents.lastTouchDate = new Date().getTime();
-      this.invalidateIfMoreThanOneTouch(event);
-
-      if (!touchEvents.invalid &&
-        Math.abs(touchEvents.downPos.clientX - touchEvents.lastPos.clientX) <= MOVE_THRESHOLD &&
-        Math.abs(touchEvents.downPos.clientY - touchEvents.lastPos.clientY) <= MOVE_THRESHOLD) {
-        if (typeof callback === 'function') {
-          callback(event);
-        }
-
-        var box = event.target.getBoundingClientRect();
-        if (touchEvents.lastPos.clientX <= box.right &&
-          touchEvents.lastPos.clientX >= box.left &&
-          touchEvents.lastPos.clientY <= box.bottom &&
-          touchEvents.lastPos.clientY >= box.top) {
-          this.props.props.onClick(event);
-        }
-      }
-
-      this.removeListeners();
-    },
-
-    onCancel: function () {
-      console.log('Cancel');
-
-      touchEvents.touched = true;
-      touchEvents.lastTouchDate = new Date().getTime();
-
-      this.removeListeners();
-    },
-
-    addListeners: function () {
-      addListener(window, 'touchmove', this.onTouchMoveWindow);
-      addListener(window, 'touchend', this.onTouchEndWindow);
-      addListener(window, 'touchcancel', this.onCancel);
-      addListener(window, 'contextmenu', this.onCancel);
-    },
-
-    removeListeners: function () {
-      removeListener(window, 'touchmove', this.onTouchMoveWindow);
-      removeListener(window, 'touchend', this.onTouchEndWindow);
-      removeListener(window, 'touchcancel', this.onCancel);
-      removeListener(window, 'contextmenu', this.onCancel);
-    },
-
-    componentWillUnmount: function () {
-      this.removeListeners();
-    },
-
-    render: function () {
-      var props = this.props.props;
-      var newProps = {};
-
-      // Loop over props
-      for (var key in props) {
-        // Copy most props to newProps
-        newProps[key] = props[key];
-      }
-
-      // Apply our wrapped mouse and touch handlers
-      newProps.onClick = this.onMouseEvent.bind(this, props.onClick);
-      newProps.onMouseDown = this.onMouseEvent.bind(this, props.onMouseDown);
-      newProps.onMouseMove = this.onMouseEvent.bind(this, props.onMouseMove);
-      newProps.onMouseUp = this.onMouseEvent.bind(this, props.onMouseUp);
-      newProps.onTouchStart = this.onTouchStart;
-      newProps.onTouchEnd = this.onTouchEnd.bind(this, props.onTouchEnd);
-
-      // Apply original type, newProps and original children to original createElement function
-      return originalCreateElement.apply(
-        null,
-        [this.props.type, newProps].concat(this.props.children)
-      );
     }
-  });
+  };
+
+  var onCancel = function () {
+    console.log('Cancel');
+
+    touchEvents.touched = true;
+    touchEvents.lastTouchDate = new Date().getTime();
+  };
+
+  var propsWithFastclickEvents = function (props) {
+    var newProps = {};
+
+    // Loop over props
+    for (var key in props) {
+      // Copy most props to newProps
+      newProps[key] = props[key];
+    }
+
+    // Apply our wrapped mouse and touch handlers
+    newProps.onClick = onMouseEvent.bind(null, props.onClick);
+    newProps.onMouseDown = onMouseEvent.bind(null, props.onMouseDown);
+    newProps.onMouseMove = onMouseEvent.bind(null, props.onMouseMove);
+    newProps.onMouseUp = onMouseEvent.bind(null, props.onMouseUp);
+    newProps.onTouchStart = onTouchStart.bind(null, props.onTouchStart);
+    newProps.onTouchMove = onTouchMove.bind(null, props.onTouchMove);
+    newProps.onTouchEnd = onTouchEnd.bind(null, props.onTouchEnd, props.onClick);
+
+    return newProps;
+  };
 
   React.createElement = function () {
     // Convert arguments to array
@@ -185,12 +143,7 @@
     if (type && typeof type === 'string' &&
       props && typeof props.onClick === 'function') {
       // Push type and props into props
-      args[1] = {
-        type: type,
-        props: props
-      };
-      // Replace type with FastClick
-      args[0] = FastClickWrapper;
+      args[1] = propsWithFastclickEvents(props);
     }
 
     // Apply args to original createElement function

--- a/index.js
+++ b/index.js
@@ -25,12 +25,15 @@
   var handleType = {
     input: function (event) {
       focusOrCheck(event.currentTarget);
+      event.preventDefault();
     },
     textarea: function (event) {
       focusOrCheck(event.currentTarget);
+      event.preventDefault();
     },
     select: function (event) {
       focusOrCheck(event.currentTarget);
+      event.stopPropagation();
     },
     label: function (event) {
       var input;
@@ -46,6 +49,7 @@
       if (input) {
         focusOrCheck(input);
       }
+      event.preventDefault();
     }
   };
 
@@ -131,7 +135,6 @@
 
         if (!event.defaultPrevented && handleType[type]) {
           handleType[type](event);
-          event.preventDefault();
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@
       this.removeListeners();
     },
 
-    onCancel: function (event) {
+    onCancel: function () {
       console.log('Cancel');
 
       touchEvents.touched = true;
@@ -188,7 +188,7 @@
       args[1] = {
         type: type,
         props: props
-      }
+      };
       // Replace type with FastClick
       args[0] = FastClickWrapper;
     }
@@ -196,6 +196,5 @@
     // Apply args to original createElement function
     return originalCreateElement.apply(null, args);
   };
-
 
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fastclick",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Fast Touch Events for React",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "react": ">=0.12.0"
   },
   "devDependencies": {
-    "jscs": "=1.13.1",
-    "jshint": "=2.8.0"
+    "jscs": "=2.8.0",
+    "jshint": "=2.9.1"
   },
   "jshintConfig": {
     "browserify": true,


### PR DESCRIPTION
- Modify elements that have `onClick` props with additional event props
- Decrease chance of memory leaks
- Fixes #13 (removing, hiding and moving elements still triggering click events)
- Click events only triggered if touch released on same element
- Allow standard onClick events to happen (allowing checkboxes, labels, inputs, focusing, etc to function)
- Handle special cases for inputs etc be focussed / accessed quickly
- Remove need for timeouts
- Handle `React.DOM.x` element creation
- Support 0.14+ (fixes #14)
- Support older versions of React (theoretically - not tested)

**New features (mentioned in / fixes #4)**
- Added `event.button = 0`
- Changed `event.type` to `click`
- Added `event.fastclick = true`
- Copy touch positions to event

**Need testers!**
Update your package.json

```
"react-fastclick": "git://github.com/jakesidsmith/react-fastclick.git#refactor-for-0.14"
```

Include react-fastclick

```
require('react-fastclick');
// or if you're using ES6
import 'react-fastclick';
```

Please post what version of react you've tested with, what devices / browsers you've tested on, which elements / components (if any) you have had problems with, and what libraries may be affecting this.
