### PR TITLE
Fix ios buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,10 +155,10 @@
     if (!touchEvents.invalid && !touchEvents.moved) {
       var box = event.currentTarget.getBoundingClientRect();
 
-      if (touchEvents.lastPos.clientX - touchEvents.lastPos.radiusX <= box.right &&
-        touchEvents.lastPos.clientX + touchEvents.lastPos.radiusX >= box.left &&
-        touchEvents.lastPos.clientY - touchEvents.lastPos.radiusY <= box.bottom &&
-        touchEvents.lastPos.clientY + touchEvents.lastPos.radiusY >= box.top) {
+      if (touchEvents.lastPos.clientX - (touchEvents.lastPos.radiusX || 0) <= box.right &&
+        touchEvents.lastPos.clientX + (touchEvents.lastPos.radiusX || 0) >= box.left &&
+        touchEvents.lastPos.clientY - (touchEvents.lastPos.radiusY || 0) <= box.bottom &&
+        touchEvents.lastPos.clientY + (touchEvents.lastPos.radiusY || 0) >= box.top) {
 
         if (typeof onClick === 'function') {
           copyTouchKeys(touchEvents.lastPos, event);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fastclick",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Fast Touch Events for React",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added a fallback for touch event radii (as iOS doesn't appear to support this).

Fixes #19 

Unfortunately click events just outside of a button still have the delay, but this is due to some weird implementation of mouse events in iOS - touch events close to an element do not get triggered, but events such as click do.
