### PR TITLE
fix: #29 sometimes clicks bleed through to other elements.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,6 +174,7 @@
 
         if (!isDisabled(event.currentTarget)) {
           if (typeof onClick === 'function') {
+            event.preventDefault();
             copyTouchKeys(touchEvents.lastPos, event);
             fakeClickEvent(event);
             onClick(event);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fastclick",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Fast Touch Events for React",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I stumbled upon this problem today, and tried my hands at a fix. Worked for me, so maybe will work for others as well.

I think the problem is because we need to prevent the handler of the original event while we issue the onClick event handler on the react-click event. Otherwise, we risk calling `onClick`, then eventually triggering the `onClick` behavior of the javascript event again on the same x,y coordinates, resulting in clicks to bleed through

There isn't a good way to inject this into the ReactUtil tests, since this is testing the js event system, not the React synthetic event system, so this PR only assures that none of the existing tests break.
