### PR TITLE
add excluded class

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,10 @@
     return disabled !== false && disabled !== null;
   };
 
+  var isExcluded = function(element) {
+    return element.classlist.contains("needsclick");
+  };
+
   var focus = function (event, target) {
     var myTarget = target || event.currentTarget;
 
@@ -172,7 +176,7 @@
         touchEvents.lastPos.clientY - (touchEvents.lastPos.radiusY || 0) <= box.bottom &&
         touchEvents.lastPos.clientY + (touchEvents.lastPos.radiusY || 0) >= box.top) {
 
-        if (!isDisabled(event.currentTarget)) {
+        if (!isDisabled(event.currentTarget) && !isExcluded(event.currentTarget)) {
           if (typeof onClick === 'function') {
             copyTouchKeys(touchEvents.lastPos, event);
             fakeClickEvent(event);


### PR DESCRIPTION
Adds an excluded classname. If you want a particular element to be skipped by fastclick, give it a `.needsclick` class. 
